### PR TITLE
Bug Fix: Correct type error in get_user_sessions endpoint

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -298,17 +298,17 @@ async def update_session_name(
 
 
 @router.get("/sessions", response_model=List[SessionResponse])
-async def get_user_sessions(user_id: int = Depends(get_current_user)):
+async def get_user_sessions(user: User = Depends(get_current_user)):
     """Get all session IDs for the authenticated user.
 
     Args:
-        user_id: The authenticated user's ID
+        user: The authenticated user
 
     Returns:
         List[SessionResponse]: List of session IDs
     """
     try:
-        sessions = await db_service.get_user_sessions(user_id)
+        sessions = await db_service.get_user_sessions(user.id)
         return [
             SessionResponse(
                 session_id=sanitize_string(session.id),
@@ -318,5 +318,5 @@ async def get_user_sessions(user_id: int = Depends(get_current_user)):
             for session in sessions
         ]
     except ValueError as ve:
-        logger.error("get_sessions_validation_failed", user_id=user_id, error=str(ve), exc_info=True)
+        logger.error("get_sessions_validation_failed", user_id=user.id, error=str(ve), exc_info=True)
         raise HTTPException(status_code=422, detail=str(ve))


### PR DESCRIPTION
### Description:

Fixes #5 

This PR addresses a type mismatch in the `/sessions` endpoint. The `get_current_user` dependency returns a `User` object, but the endpoint was expecting an `int`, causing a SQLAlchemy error. This PR changes the parameter to accept a `User` and uses `user.id` in the DB call.

for detailed explanation of the bug, and the proposed fix, please review the issue #5 .
