### PR TITLE
Added cAdvisor (Container Advisor) provides container users an understanding of the resource usage and performance characteristics of their running containers.

### DIFF
--- a/app/api/v1/chatbot.py
+++ b/app/api/v1/chatbot.py
@@ -14,7 +14,7 @@ from fastapi import (
     Request,
 )
 from fastapi.responses import StreamingResponse
-
+from app.core.metrics import llm_stream_duration_seconds
 from app.api.v1.auth import get_current_session
 from app.core.config import settings
 from app.core.langgraph.graph import LangGraphAgent
@@ -30,6 +30,7 @@ from app.schemas.chat import (
 
 router = APIRouter()
 agent = LangGraphAgent()
+
 
 
 @router.post("/chat", response_model=ChatResponse)
@@ -59,8 +60,11 @@ async def chat(
             message_count=len(chat_request.messages),
         )
 
-        # Process the request through the LangGraph
-        result = await agent.get_response(chat_request.messages, session.id, user_id=session.user_id)
+       
+
+        result = await agent.get_response(
+            chat_request.messages, session.id, user_id=session.user_id
+        )
 
         logger.info("chat_request_processed", session_id=session.id)
 
@@ -108,12 +112,13 @@ async def chat_stream(
             """
             try:
                 full_response = ""
-                async for chunk in agent.get_stream_response(
-                    chat_request.messages, session.id, user_id=session.user_id
-                ):
-                    full_response += chunk
-                    response = StreamResponse(content=chunk, done=False)
-                    yield f"data: {json.dumps(response.model_dump())}\n\n"
+                with llm_stream_duration_seconds.labels(model=agent.llm.model_name).time():
+                    async for chunk in agent.get_stream_response(
+                        chat_request.messages, session.id, user_id=session.user_id
+                     ):
+                        full_response += chunk
+                        response = StreamResponse(content=chunk, done=False)
+                        yield f"data: {json.dumps(response.model_dump())}\n\n"
 
                 # Send final message indicating completion
                 final_response = StreamResponse(content="", done=True)

--- a/app/core/langgraph/graph.py
+++ b/app/core/langgraph/graph.py
@@ -25,7 +25,7 @@ from langgraph.graph.state import CompiledStateGraph
 from langgraph.types import StateSnapshot
 from openai import OpenAIError
 from psycopg_pool import AsyncConnectionPool
-
+from app.core.metrics import llm_inference_duration_seconds 
 from app.core.config import (
     Environment,
     settings,
@@ -136,7 +136,8 @@ class LangGraphAgent:
 
         for attempt in range(max_retries):
             try:
-                generated_state = {"messages": [await self.llm.ainvoke(dump_messages(messages))]}
+                with llm_inference_duration_seconds.labels(model=self.llm.model_name).time():
+                    generated_state = {"messages": [await self.llm.ainvoke(dump_messages(messages))]}
                 logger.info(
                     "llm_response_generated",
                     session_id=state.session_id,

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -19,6 +19,22 @@ db_connections = Gauge("db_connections", "Number of active database connections"
 # Custom business metrics
 orders_processed = Counter("orders_processed_total", "Total number of orders processed")
 
+llm_inference_duration_seconds = Histogram(
+    "llm_inference_duration_seconds",
+    "Time spent processing LLM inference",
+    ["model"],
+    buckets=[0.1, 0.3, 0.5, 1.0, 2.0, 5.0]
+)
+
+
+
+llm_stream_duration_seconds = Histogram(
+    "llm_stream_duration_seconds",
+    "Time spent processing LLM stream inference",
+    ["model"],
+    buckets=[0.1, 0.5, 1.0, 2.0, 5.0, 10.0]
+)
+
 
 def setup_metrics(app):
     """Set up Prometheus metrics middleware and endpoints.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,12 +51,28 @@ services:
       - "3000:3000"
     volumes:
       - grafana-storage:/var/lib/grafana
+      - ./grafana/dashboards:/etc/grafana/provisioning/dashboards
+      - ./grafana/dashboards/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
     networks:
       - monitoring
     restart: always
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    networks:
+      - monitoring
+    restart: always
+
 
 networks:
   monitoring:

--- a/grafana/dashboards/dashboards.yml
+++ b/grafana/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/json

--- a/grafana/dashboards/json/llm_latency.json
+++ b/grafana/dashboards/json/llm_latency.json
@@ -6,7 +6,7 @@
     "tags": ["inference", "latency"],
     "timezone": "browser",
     "schemaVersion": 30,
-    "version": 2,
+    "version": 3,
     "refresh": "10s",
     "panels": [
       {
@@ -16,7 +16,6 @@
           {
             "expr": "histogram_quantile(0.95, rate(llm_inference_duration_seconds_bucket[1m]))",
             "legendFormat": "{{model}} (chat)",
-            "interval": "",
             "refId": "A"
           }
         ],
@@ -30,12 +29,37 @@
           {
             "expr": "histogram_quantile(0.95, rate(llm_stream_duration_seconds_bucket[1m]))",
             "legendFormat": "{{model}} (stream)",
-            "interval": "",
             "refId": "B"
           }
         ],
         "datasource": "Prometheus",
         "gridPos": { "x": 0, "y": 9, "w": 24, "h": 9 }
+      },
+      {
+        "type": "graph",
+        "title": "LLM Inference Duration (Average)",
+        "targets": [
+          {
+            "expr": "rate(llm_inference_duration_seconds_sum[1m]) / rate(llm_inference_duration_seconds_count[1m])",
+            "legendFormat": "{{model}} (avg)",
+            "refId": "C"
+          }
+        ],
+        "datasource": "Prometheus",
+        "gridPos": { "x": 0, "y": 18, "w": 24, "h": 9 }
+      },
+      {
+        "type": "graph",
+        "title": "LLM Inference Request Count",
+        "targets": [
+          {
+            "expr": "rate(llm_inference_duration_seconds_count[1m])",
+            "legendFormat": "{{model}}",
+            "refId": "D"
+          }
+        ],
+        "datasource": "Prometheus",
+        "gridPos": { "x": 0, "y": 27, "w": 24, "h": 9 }
       }
     ]
   },

--- a/grafana/dashboards/json/llm_latency.json
+++ b/grafana/dashboards/json/llm_latency.json
@@ -1,0 +1,43 @@
+{
+  "dashboard": {
+    "id": null,
+    "uid": "llm-latency",
+    "title": "LLM Inference Latency",
+    "tags": ["inference", "latency"],
+    "timezone": "browser",
+    "schemaVersion": 30,
+    "version": 2,
+    "refresh": "10s",
+    "panels": [
+      {
+        "type": "graph",
+        "title": "LLM Inference Duration (p95)",
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, rate(llm_inference_duration_seconds_bucket[1m]))",
+            "legendFormat": "{{model}} (chat)",
+            "interval": "",
+            "refId": "A"
+          }
+        ],
+        "datasource": "Prometheus",
+        "gridPos": { "x": 0, "y": 0, "w": 24, "h": 9 }
+      },
+      {
+        "type": "graph",
+        "title": "LLM Stream Inference Duration (p95)",
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, rate(llm_stream_duration_seconds_bucket[1m]))",
+            "legendFormat": "{{model}} (stream)",
+            "interval": "",
+            "refId": "B"
+          }
+        ],
+        "datasource": "Prometheus",
+        "gridPos": { "x": 0, "y": 9, "w": 24, "h": 9 }
+      }
+    ]
+  },
+  "overwrite": true
+}

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -4,7 +4,11 @@ global:
 
 scrape_configs:
   - job_name: 'fastapi'
+    metrics_path: '/metrics'
+    scheme: 'http'
     static_configs:
       - targets: ['app:8000']
-    metrics_path: '/metrics'
-    scheme: 'http' 
+
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['cadvisor:8080']


### PR DESCRIPTION
Added Prometheus metric to track LLM stream inference latency by model

- I Introduced `llm_stream_duration_seconds` histogram metric in `metrics.py`
-I  Wrapped async stream generator in `/chat/stream` to measure streaming duration
- I Capture streaming inference latency with model label (e.g., "gpt-4o")

This enables precise tracking of streamed LLM performance in Grafana and Prometheus, independent of standard chat duration metrics.Pls test before you accaept PR
