### PR TITLE
Fix README's description to run app (make prod)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ uv sync
 2. Run the application:
 
 ```bash
-make [dev|staging|production] # e.g. make dev
+make [dev|staging|prod] # e.g. make dev
 ```
 
 1. Go to Swagger UI:


### PR DESCRIPTION
The Readme tells to run `make production` to run the app in production, but the Makefile expects `make prod`