### PR TITLE
Add missing dependency when running in the Mac

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "langgraph>=1.0.2",
     "langgraph-checkpoint-postgres>=3.0.1",
     "passlib[bcrypt]>=1.7.4",
+    "psycopg[binary]>=3.3.2",
     "psycopg2-binary>=2.9.10",
     "pydantic[email]>=2.11.1",
     "pydantic-settings>=2.8.1",


### PR DESCRIPTION
I got the error bellow when try to run the app locally in a Macbook M1. It got fixed when I added this dependency.

```
couldn't use pg_config to find libpq: [Errno 2] No such file or directory: 'pg_config'                                                                              
Process SpawnProcess-1:                                                                                                                                             
Traceback (most recent call last):                                                                                                                                  
  File "/Users/alexsandro.souza/.pyenv/versions/3.13.2/lib/python3.13/multiprocessing/process.py", line 313, in _bootstrap                                          
    self.run()                                                                                                                                                      
    ~~~~~~~~^^                                                                                                                                                      
  File "/Users/alexsandro.souza/.pyenv/versions/3.13.2/lib/python3.13/multiprocessing/process.py", line 108, in run                                                 
    self._target(*self._args, **self._kwargs)                                                                                                                       
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                       
  File "/Users/alexsandro.souza/projects/my/fastapi-langgraph-agent-production-ready-template/.venv/lib/python3.13/site-packages/uvicorn/_subprocess.py", line      
80, in subprocess_started                                                                                                                                           
    target(sockets=sockets)                                                                                                                                         
    ~~~~~~^^^^^^^^^^^^^^^^^                                                                                                                                         
  File "/Users/alexsandro.souza/projects/my/fastapi-langgraph-agent-production-ready-template/.venv/lib/python3.13/site-packages/uvicorn/server.py", line 66, in    
 run                                                                                                                                                                
    return asyncio.run(self.serve(sockets=sockets))                                                                                                                 
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                 
  File "/Users/alexsandro.souza/.pyenv/versions/3.13.2/lib/python3.13/asyncio/runners.py", line 195, in run                                                         
    return runner.run(main)                                                                                                                                         
           ~~~~~~~~~~^^^^^^                                                                                                                                         
  File "/Users/alexsandro.souza/.pyenv/versions/3.13.2/lib/python3.13/asyncio/runners.py", line 118, in run                                                         
    return self._loop.run_until_complete(task)                                                                                                                      
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^                                                                                                                      
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete                                                                                         
  File "/Users/alexsandro.souza/projects/my/fastapi-langgraph-agent-production-ready-template/.venv/lib/python3.13/site-packages/uvicorn/server.py", line 70, in    
 serve                                                                                                                                                              
    await self._serve(sockets)                                                                                                                                      
  File "/Users/alexsandro.souza/projects/my/fastapi-langgraph-agent-production-ready-template/.venv/lib/python3.13/site-packages/uvicorn/server.py", line 77, in    
 _serve                                                                                                                                                             
    config.load()                                                                                                                                                   
    ~~~~~~~~~~~^^                                                                                                                                                   
  File "/Users/alexsandro.souza/projects/my/fastapi-langgraph-agent-production-ready-template/.venv/lib/python3.13/site-packages/uvicorn/config.py", line 435,      
in load                                                                                                                                                             
    self.loaded_app = import_from_string(self.app)                                                                                                                  
                      ~~~~~~~~~~~~~~~~~~^^^^^^^^^^                                                                                                                  
  File "/Users/alexsandro.souza/projects/my/fastapi-langgraph-agent-production-ready-template/.venv/lib/python3.13/site-packages/uvicorn/importer.py", line 19,     
in import_from_string                                                                                                                                               
    module = importlib.import_module(module_str)                                                                                                                    
  File "/Users/alexsandro.souza/.pyenv/versions/3.13.2/lib/python3.13/importlib/__init__.py", line 88, in import_module                                             
    return _bootstrap._gcd_import(name[level:], package, level)                                                                                                     
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                     
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import                                                                                                   
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load                                                                                                
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked                                                                                       
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked                                                                                                 
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module                                                                                          
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed                                                                                      
  File "/Users/alexsandro.souza/projects/my/fastapi-langgraph-agent-production-ready-template/app/main.py", line 24, in <module>                                    
    from app.api.v1.api import api_router                                                                                                                           
  File "/Users/alexsandro.souza/projects/my/fastapi-langgraph-agent-production-ready-template/app/api/v1/api.py", line 10, in <module>                              
    from app.api.v1.chatbot import router as chatbot_router                                                                                                         
  File "/Users/alexsandro.souza/projects/my/fastapi-langgraph-agent-production-ready-template/app/api/v1/chatbot.py", line 20, in <module>                          
    from app.core.langgraph.graph import LangGraphAgent                                                                                                             
  File "/Users/alexsandro.souza/projects/my/fastapi-langgraph-agent-production-ready-template/app/core/langgraph/graph.py", line 17, in <module>                    
    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver                                                                                                
  File "/Users/alexsandro.souza/projects/my/fastapi-langgraph-agent-production-ready-template/.venv/lib/python3.13/site-packages/langgraph/checkpoint/postgres/_    
_init__.py", line 20, in <module>                                                                                                                                   
    from psycopg import Capabilities, Connection, Cursor, Pipeline                                                                                                  
  File "/Users/alexsandro.souza/projects/my/fastapi-langgraph-agent-production-ready-template/.venv/lib/python3.13/site-packages/psycopg/__init__.py", line 9,      
in <module>                                                                                                                                                         
    from . import pq  # noqa: F401 import early to stabilize side effects                                                                                           
    ^^^^^^^^^^^^^^^^                                                                                                                                                
  File "/Users/alexsandro.souza/projects/my/fastapi-langgraph-agent-production-ready-template/.venv/lib/python3.13/site-packages/psycopg/pq/__init__.py", line      
116, in <module>                                                                                                                                                    
    import_from_libpq()                                                                                                                                             
    ~~~~~~~~~~~~~~~~~^^                                                                                                                                             
  File "/Users/alexsandro.souza/projects/my/fastapi-langgraph-agent-production-ready-template/.venv/lib/python3.13/site-packages/psycopg/pq/__init__.py", line      
108, in import_from_libpq                                                                                                                                           
            raise ImportError(                                                                                                                                      
    ...<4 lines>...                                                                                                                                                 
            )                                                                                                                                                       
ImportError: no pq wrapper available.                                                                                                                               
Attempts made:                                                                                                                                                      
- couldn't import psycopg 'c' implementation: No module named 'psycopg_c'                                                                                           
- couldn't import psycopg 'binary' implementation: No module named 'psycopg_binary'                                                                                 
- couldn't import psycopg 'python' implementation: libpq library not found
```