### PR TITLE
Fix eval flow

### DIFF
--- a/evals/evaluator.py
+++ b/evals/evaluator.py
@@ -47,7 +47,11 @@ class Evaluator:
     def __init__(self):
         """Initialize Evaluator with OpenAI and Langfuse clients."""
         self.client = openai.AsyncOpenAI(api_key=settings.EVALUATION_API_KEY, base_url=settings.EVALUATION_BASE_URL)
-        self.langfuse = Langfuse(public_key=settings.LANGFUSE_PUBLIC_KEY, secret_key=settings.LANGFUSE_SECRET_KEY)
+        self.langfuse = Langfuse(
+            public_key=settings.LANGFUSE_PUBLIC_KEY,
+            secret_key=settings.LANGFUSE_SECRET_KEY,
+            timeout=60,  # In seconds
+        )
         # Initialize report data structure
         self.report = initialize_report(settings.EVALUATION_LLM)
         initialize_metrics_summary(self.report, metrics)
@@ -186,6 +190,7 @@ class Evaluator:
             List of traces that haven't been scored yet.
         """
         last_24_hours = datetime.now() - timedelta(hours=24)
+        logger.info("fetching_langfuse_traces", from_timestamp=str(last_24_hours))
         try:
             traces = self.langfuse.api.trace.list(
                 from_timestamp=last_24_hours, order_by="timestamp.asc", limit=100

--- a/evals/helpers.py
+++ b/evals/helpers.py
@@ -30,8 +30,14 @@ def format_messages(messages: list[dict]) -> str:
     formatted_messages = []
     for idx, message in enumerate(messages):
         if message["type"] == "tool":
+            previous_message = messages[idx - 1]
+            tool_call = previous_message.get('additional_kwargs', {}).get('tool_calls', [])
+            if tool_call:
+                args = tool_call[0].get('function', {}).get('arguments')
+            else:
+                args = previous_message.get('tool_calls')[0].get('args') if previous_message.get('tool_calls') else {}
             formatted_messages.append(
-                f"tool {message.get('name')} input: {messages[idx - 1].get('additional_kwargs', {}).get('tool_calls', [])[0].get('function', {}).get('arguments')} {message.get('content')[:100]}..."
+                f"tool {message.get('name')} input: {args} {message.get('content')[:100]}..."
                 if len(message.get("content", "")) > 100
                 else f"tool {message.get('name')}: {message.get('content')}"
             )


### PR DESCRIPTION
The Eval flow is not working when there is tool call in the messages. The formatting is failing because the message structure is different from expected. 

```
✗ Evaluation failed: list index out of range
```

<img width="1203" height="258" alt="Screenshot 2025-12-30 at 16 08 23" src="https://github.com/user-attachments/assets/1521ec07-a64d-4643-820f-5fb2a12d6c69" />
