### PR TITLE
Fix: Remove the failing command from the Build image step

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,7 +30,6 @@ jobs:
       - name: Build Image
         run: |
           make docker-build-env ENV=production
-          docker tag fastapi-langgraph-template:production ${{ secrets.DOCKER_USERNAME }}/${{ env.REPO_NAME }}:production
 
       - name: Log in to Docker Hub
         run: |
@@ -38,6 +37,7 @@ jobs:
 
       - name: Push Image
         run: |
+          docker tag fastapi-langgraph-template:production ${{ secrets.DOCKER_USERNAME }}/${{ env.REPO_NAME }}:production
           docker push ${{ secrets.DOCKER_USERNAME }}/${{ env.REPO_NAME }}:production
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,14 +31,14 @@ jobs:
         run: |
           make docker-build-env ENV=production
 
-      - name: Log in to Docker Hub
-        run: |
-          echo ${{ secrets.DOCKER_PASSWORD }} | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
-
-      - name: Push Image
-        run: |
-          docker tag fastapi-langgraph-template:production ${{ secrets.DOCKER_USERNAME }}/${{ env.REPO_NAME }}:production
-          docker push ${{ secrets.DOCKER_USERNAME }}/${{ env.REPO_NAME }}:production
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+#      - name: Log in to Docker Hub
+#        run: |
+#          echo ${{ secrets.DOCKER_PASSWORD }} | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
+#
+#      - name: Push Image
+#        run: |
+#          docker tag fastapi-langgraph-template:production ${{ secrets.DOCKER_USERNAME }}/${{ env.REPO_NAME }}:production
+#          docker push ${{ secrets.DOCKER_USERNAME }}/${{ env.REPO_NAME }}:production
+#        env:
+#          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+#          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
It seems that the repository is missing DOCKER_USERNAME. This is making the pipeline fail. we should either add this secret or disable the steps requiring it