### PR TITLE
feat: add optional username field for LLM personalization

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -177,13 +177,20 @@ async def register_user(request: Request, user_data: UserCreate):
         if await db_service.get_user_by_email(sanitized_email):
             raise HTTPException(status_code=400, detail="Email already registered")
 
+        # Sanitize optional username
+        sanitized_username = sanitize_string(user_data.username) if user_data.username else None
+
         # Create user
-        user = await db_service.create_user(email=sanitized_email, password=User.hash_password(password))
+        user = await db_service.create_user(
+            email=sanitized_email,
+            password=User.hash_password(password),
+            username=sanitized_username,
+        )
 
         # Create access token
         token = create_access_token(str(user.id))
 
-        return UserResponse(id=user.id, email=user.email, token=token)
+        return UserResponse(id=user.id, email=user.email, username=user.username, token=token)
     except ValueError as ve:
         logger.exception("user_registration_validation_failed", error=str(ve))
         raise HTTPException(status_code=422, detail=str(ve))
@@ -250,8 +257,8 @@ async def create_session(user: User = Depends(get_current_user)):
         # Generate a unique session ID
         session_id = str(uuid.uuid4())
 
-        # Create session in database
-        session = await db_service.create_session(session_id, user.id)
+        # Create session in database, copying username for LLM personalization
+        session = await db_service.create_session(session_id, user.id, username=user.username)
 
         # Create access token for the session
         token = create_access_token(session_id)

--- a/app/api/v1/chatbot.py
+++ b/app/api/v1/chatbot.py
@@ -60,7 +60,9 @@ async def chat(
             message_count=len(chat_request.messages),
         )
 
-        result = await agent.get_response(chat_request.messages, session.id, user_id=session.user_id)
+        result = await agent.get_response(
+            chat_request.messages, session.id, user_id=session.user_id, username=session.username
+        )
 
         logger.info("chat_request_processed", session_id=session.id)
 
@@ -109,7 +111,7 @@ async def chat_stream(
             try:
                 with llm_stream_duration_seconds.labels(model=agent.llm_service.get_llm().get_name()).time():
                     async for chunk in agent.get_stream_response(
-                        chat_request.messages, session.id, user_id=session.user_id
+                        chat_request.messages, session.id, user_id=session.user_id, username=session.username
                     ):
                         response = StreamResponse(content=chunk, done=False)
                         yield f"data: {json.dumps(response.model_dump())}\n\n"

--- a/app/core/langgraph/graph.py
+++ b/app/core/langgraph/graph.py
@@ -127,7 +127,8 @@ class LangGraphAgent:
             else settings.DEFAULT_LLM_MODEL
         )
 
-        SYSTEM_PROMPT = load_system_prompt(long_term_memory=state.long_term_memory)
+        username = config.get("metadata", {}).get("username")
+        SYSTEM_PROMPT = load_system_prompt(username=username, long_term_memory=state.long_term_memory)
 
         # Prepare messages with system prompt
         messages = prepare_messages(state.messages, SYSTEM_PROMPT)
@@ -241,6 +242,7 @@ class LangGraphAgent:
         messages: list[Message],
         session_id: str,
         user_id: Optional[str] = None,
+        username: Optional[str] = None,
     ) -> list[dict]:
         """Get a response from the LLM.
 
@@ -248,6 +250,7 @@ class LangGraphAgent:
             messages (list[Message]): The messages to send to the LLM.
             session_id (str): The session ID for the conversation.
             user_id (Optional[str]): The user ID for the conversation.
+            username (Optional[str]): The display name of the user.
 
         Returns:
             list[dict]: The response from the LLM.
@@ -260,6 +263,7 @@ class LangGraphAgent:
             "callbacks": callbacks,
             "metadata": {
                 "user_id": user_id,
+                "username": username,
                 "session_id": session_id,
                 "environment": settings.ENVIRONMENT.value,
                 "debug": settings.DEBUG,
@@ -307,7 +311,11 @@ class LangGraphAgent:
             raise
 
     async def get_stream_response(
-        self, messages: list[Message], session_id: str, user_id: Optional[str] = None
+        self,
+        messages: list[Message],
+        session_id: str,
+        user_id: Optional[str] = None,
+        username: Optional[str] = None,
     ) -> AsyncGenerator[str, None]:
         """Get a stream response from the LLM.
 
@@ -315,6 +323,7 @@ class LangGraphAgent:
             messages (list[Message]): The messages to send to the LLM.
             session_id (str): The session ID for the conversation.
             user_id (Optional[str]): The user ID for the conversation.
+            username (Optional[str]): The display name of the user.
 
         Yields:
             str: Tokens of the LLM response.
@@ -325,6 +334,7 @@ class LangGraphAgent:
             "callbacks": callbacks,
             "metadata": {
                 "user_id": user_id,
+                "username": username,
                 "session_id": session_id,
                 "environment": settings.ENVIRONMENT.value,
                 "debug": settings.DEBUG,

--- a/app/core/prompts/__init__.py
+++ b/app/core/prompts/__init__.py
@@ -2,6 +2,7 @@
 
 import os
 from datetime import datetime
+from typing import Optional
 
 from app.core.config import settings
 
@@ -10,10 +11,12 @@ with open(os.path.join(os.path.dirname(__file__), "system.md"), "r") as _f:
     _SYSTEM_PROMPT_TEMPLATE = _f.read()
 
 
-def load_system_prompt(**kwargs):
+def load_system_prompt(username: Optional[str] = None, **kwargs):
     """Load the system prompt from the cached template."""
+    user_context = f"# User\nYou are talking to {username}.\n" if username else ""
     return _SYSTEM_PROMPT_TEMPLATE.format(
         agent_name=settings.PROJECT_NAME + " Agent",
         current_date_and_time=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        user_context=user_context,
         **kwargs,
     )

--- a/app/core/prompts/system.md
+++ b/app/core/prompts/system.md
@@ -7,6 +7,7 @@ Help the user with their questions.
 - If you don't know the answer, say you don't know. Don't make up an answer.
 - Try to give the most accurate answer possible.
 
+{user_context}
 # What you know about the user
 {long_term_memory}
 

--- a/app/models/session.py
+++ b/app/models/session.py
@@ -3,6 +3,7 @@
 from typing import (
     TYPE_CHECKING,
     List,
+    Optional,
 )
 
 from sqlmodel import (
@@ -23,6 +24,7 @@ class Session(BaseModel, table=True):
         id: The primary key
         user_id: Foreign key to the user
         name: Name of the session (defaults to empty string)
+        username: Display name copied from the user at session creation
         created_at: When the session was created
         messages: Relationship to session messages
         user: Relationship to the session owner
@@ -31,4 +33,5 @@ class Session(BaseModel, table=True):
     id: str = Field(primary_key=True)
     user_id: int = Field(foreign_key="user.id")
     name: str = Field(default="")
+    username: Optional[str] = Field(default=None)
     user: "User" = Relationship(back_populates="sessions")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -3,6 +3,7 @@
 from typing import (
     TYPE_CHECKING,
     List,
+    Optional,
 )
 
 import bcrypt
@@ -24,6 +25,7 @@ class User(BaseModel, table=True):
         id: The primary key
         email: User's email (unique)
         hashed_password: Bcrypt hashed password
+        username: Optional display name for the user
         created_at: When the user was created
         sessions: Relationship to user's chat sessions
     """
@@ -31,6 +33,7 @@ class User(BaseModel, table=True):
     id: int = Field(default=None, primary_key=True)
     email: str = Field(unique=True, index=True)
     hashed_password: str
+    username: Optional[str] = Field(default=None, index=False)
     sessions: List["Session"] = Relationship(back_populates="user")
 
     def verify_password(self, password: str) -> bool:

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -48,10 +48,12 @@ class UserCreate(BaseModel):
     Attributes:
         email: User's email address
         password: User's password
+        username: Optional display name
     """
 
     email: EmailStr = Field(..., description="User's email address")
     password: SecretStr = Field(..., description="User's password", min_length=8, max_length=64)
+    username: str | None = Field(default=None, description="Optional display name", max_length=50)
 
     @field_validator("password")
     @classmethod
@@ -94,11 +96,13 @@ class UserResponse(BaseResponse):
     Attributes:
         id: User's ID
         email: User's email address
+        username: Optional display name
         token: Authentication token
     """
 
     id: int = Field(..., description="User's ID")
     email: str = Field(..., description="User's email address")
+    username: str | None = Field(default=None, description="Optional display name")
     token: Token = Field(..., description="Authentication token")
 
 

--- a/app/services/database.py
+++ b/app/services/database.py
@@ -70,18 +70,19 @@ class DatabaseService:
             if settings.ENVIRONMENT != Environment.PRODUCTION:
                 raise
 
-    async def create_user(self, email: str, password: str) -> User:
+    async def create_user(self, email: str, password: str, username: str | None = None) -> User:
         """Create a new user.
 
         Args:
             email: User's email address
             password: Hashed password
+            username: Optional display name
 
         Returns:
             User: The created user
         """
         with Session(self.engine) as session:
-            user = User(email=email, hashed_password=password)
+            user = User(email=email, hashed_password=password, username=username)
             session.add(user)
             session.commit()
             session.refresh(user)
@@ -134,19 +135,22 @@ class DatabaseService:
             logger.info("user_deleted", email=email)
             return True
 
-    async def create_session(self, session_id: str, user_id: int, name: str = "") -> ChatSession:
+    async def create_session(
+        self, session_id: str, user_id: int, name: str = "", username: str | None = None
+    ) -> ChatSession:
         """Create a new chat session.
 
         Args:
             session_id: The ID for the new session
             user_id: The ID of the user who owns the session
             name: Optional name for the session (defaults to empty string)
+            username: Display name copied from the user for LLM personalization
 
         Returns:
             ChatSession: The created session
         """
         with Session(self.engine) as session:
-            chat_session = ChatSession(id=session_id, user_id=user_id, name=name)
+            chat_session = ChatSession(id=session_id, user_id=user_id, name=name, username=username)
             session.add(chat_session)
             session.commit()
             session.refresh(chat_session)


### PR DESCRIPTION
- Add optional username to User model and registration endpoint
- Copy username to Session at creation time for efficient lookup
- Inject "You are talking to {username}." into system prompt only when set
- Thread username through graph config metadata with zero token overhead when absent
- Update chat endpoints to pass username to agent

The username is copied to the session at creation, so chat requests need no additional DB lookups—username flows directly from session.

Closes: LLM personalization feature request