### PR TITLE
docs: add FAQ section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,50 @@ Report security issues privately — see [SECURITY.md](SECURITY.md).
 ## License
 
 See [LICENSE](LICENSE).
+
+## FAQ
+
+### General
+
+**What is this template?**
+A production-ready foundation for AI agent backends built on FastAPI + LangGraph. It bundles the components you'd otherwise wire up by hand: stateful conversations, long-term memory, tool calling, observability, rate limiting, and JWT auth.
+
+**How does this differ from a basic LangGraph setup?**
+The base LangGraph quickstart stops at "agent runs locally". This template adds Alembic migrations, mem0 + pgvector long-term memory, Langfuse tracing, Prometheus + Grafana dashboards, JWT sessions, slowapi rate limiting, structured logging with per-request context, and a circular-fallback LLM service — production concerns you'd otherwise build separately.
+
+### Setup & Configuration
+
+**Do I need Docker?**
+Recommended but not required. `make docker-up` starts the API + PostgreSQL together. For local-only setup see [docs/getting-started.md](docs/getting-started.md).
+
+**Which LLM providers are supported?**
+Today: **OpenAI only** via the `LLMRegistry` in `app/services/llm/registry.py`. Multi-provider support (Anthropic, Google, OpenRouter) via LangChain's `init_chat_model` is planned — see [#51](https://github.com/wassim249/fastapi-langgraph-agent-production-ready-template/issues/51). Configure your model via `DEFAULT_LLM_MODEL` in `.env.development`.
+
+**How do I configure long-term memory?**
+Long-term memory is self-hosted: mem0 runs in-process and persists into your existing PostgreSQL via pgvector — there is no separate mem0 cloud account or API key. You only need a working `OPENAI_API_KEY` (used for fact extraction + embeddings) and the pgvector extension enabled. See [docs/memory.md](docs/memory.md) for details.
+
+### Development
+
+**How do I add a custom tool?**
+Drop a LangChain `@tool`-decorated function in `app/core/langgraph/tools/` and register it in the `tools` list exported from that package. The agent picks it up on next start; no graph changes needed.
+
+**How does the LLM service handle failures?**
+Two layers: (1) per-call exponential-backoff retry via `tenacity`, (2) **circular fallback** — if the active model exhausts its retries, the service rotates to the next model in `LLMRegistry` and continues. A total timeout budget caps the whole call so latency stays bounded. See [docs/llm-service.md](docs/llm-service.md).
+
+**Can I use this without Langfuse?**
+Yes. Set `LANGFUSE_TRACING_ENABLED=false` (or omit the Langfuse keys). The agent runs unchanged; structured logs still capture request/session/user context.
+
+### Troubleshooting
+
+**The API won't start**
+- Ensure PostgreSQL is running (`make docker-up` brings it up alongside the API)
+- Confirm `.env.development` exists — copy from `.env.example` and fill in required keys
+- Apply migrations: `make migrate`
+
+**Memory / semantic search returns nothing**
+- Verify the `pgvector` extension is enabled in your PostgreSQL instance
+- Confirm `OPENAI_API_KEY` is valid (mem0 calls OpenAI for fact extraction + embeddings)
+- Check `LONG_TERM_MEMORY_MODEL` and `LONG_TERM_MEMORY_EMBEDDER_MODEL` are set in `.env.development`
+
+**Rate limiting is too aggressive**
+Limits are defined in `app/core/limiter.py` (slowapi). Adjust per-route decorators or the default rate in that file. See [docs/configuration.md](docs/configuration.md) for the related env vars.


### PR DESCRIPTION
## Summary
- Adds an FAQ section to `README.md` covering general / setup / development / troubleshooting questions.
- Adapted from #70 by @meichuanyi with three corrections:
  - LLM providers: clarified that the registry is OpenAI-only today; multi-provider via `init_chat_model` is planned in #51, not current.
  - mem0: removed the nonexistent API-key reference. Memory is self-hosted via pgvector; only `OPENAI_API_KEY` is needed.
  - Rate-limit troubleshooting now points at `app/core/limiter.py` (slowapi) instead of `middleware.py`.

## Test plan
- [x] `make lint` clean (no Python files touched)
- [x] All referenced docs paths exist (`docs/getting-started.md`, `docs/memory.md`, `docs/llm-service.md`, `docs/configuration.md`)
- [x] All referenced Makefile targets exist (`make docker-up`, `make migrate`, `make install`)