### PR TITLE
feat: add retry policy to tool_call + docs catch-up

### DIFF
--- a/app/core/langgraph/graph.py
+++ b/app/core/langgraph/graph.py
@@ -27,7 +27,10 @@ from langgraph.graph.state import (
     Command,
     CompiledStateGraph,
 )
-from langgraph.types import StateSnapshot
+from langgraph.types import (
+    RetryPolicy,
+    StateSnapshot,
+)
 from psycopg import (
     AsyncConnection,
     sql,
@@ -218,7 +221,12 @@ class LangGraphAgent:
             try:
                 graph_builder = StateGraph(GraphState)
                 graph_builder.add_node("chat", self._chat, destinations=("tool_call", END))
-                graph_builder.add_node("tool_call", self._tool_call, destinations=("chat",))
+                graph_builder.add_node(
+                    "tool_call",
+                    self._tool_call,
+                    destinations=("chat",),
+                    retry_policy=RetryPolicy(max_attempts=3),
+                )
                 graph_builder.set_entry_point("chat")
                 graph_builder.set_finish_point("chat")
 

--- a/docs/llm-service.md
+++ b/docs/llm-service.md
@@ -2,7 +2,12 @@
 
 ## Overview
 
-The LLM service (`app/services/llm.py`) handles all language model calls with automatic retries, circular model fallback, and a total timeout budget. Your agent code calls `llm_service.call(messages)` — the service handles everything else.
+The LLM service (`app/services/llm/`) handles all language model calls with automatic retries, circular model fallback, and a total timeout budget. Your agent code calls `llm_service.call(messages)` — the service handles everything else.
+
+The package is split into two modules:
+
+- `app/services/llm/registry.py` — `LLMRegistry`: defines available models
+- `app/services/llm/service.py` — `LLMService`: call logic, retries, fallback, structured output
 
 ## Model registry
 
@@ -17,7 +22,7 @@ Models are defined in `LLMRegistry.LLMS` in order of preference:
 
 Set `DEFAULT_LLM_MODEL` in your `.env` to choose the starting model.
 
-To add or change models, edit `LLMRegistry.LLMS` in `app/services/llm.py`.
+To add or change models, edit `LLMRegistry.LLMS` in `app/services/llm/registry.py`.
 
 ## Retry and fallback behaviour
 
@@ -65,10 +70,27 @@ llm_service.bind_tools(tools)
 
 When a model is switched during fallback, the tools are re-bound to the new model automatically.
 
+## Structured output
+
+Pass a Pydantic model as `response_format` to get a validated instance back instead of a raw `BaseMessage`:
+
+```python
+from app.schemas.my_schema import MySchema
+
+result: MySchema = await llm_service.call(
+    messages,
+    model_name="gpt-5.4-nano",   # optional — uses current default if omitted
+    response_format=MySchema,
+    temperature=0.2,
+)
+```
+
+The service chains `.with_structured_output(schema)` on the resolved model and re-wraps it on every fallback attempt, so retries and model switching work transparently.
+
 ## Adding a new model
 
 ```python
-# app/services/llm.py — LLMRegistry.LLMS
+# app/services/llm/registry.py — LLMRegistry.LLMS
 {
     "name": "gpt-5.4",
     "llm": ChatOpenAI(


### PR DESCRIPTION
## Summary
Two small changes bundled into one PR:

1. **`feat: add retry policy to tool_call node`** — wraps tool execution in `RetryPolicy(max_attempts=3)` so transient tool failures (network blips, ddg rate limits, etc.) don't surface to the user as a hard error.
2. **`docs: catch up llm-service guide with the registry/service split`** — the `app/services/llm.py` → `app/services/llm/{registry,service}.py` split landed in #62 but the guide in `docs/llm-service.md` still referred to the old single-file layout. Updated paths and added a section on the structured-output (`response_format`) path.

## Test plan
- [x] Rebased onto post-#68 master cleanly (only conflict was the `ends=` → `destinations=` rename on the same line we're modifying)
- [x] `make typecheck` clean
- [x] Pre-commit hooks pass (ruff, ruff-format, detect-secrets)