### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,14 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 
 # LLM Settings
 OPENAI_API_KEY="your-llm-api-key" # e.g. OpenAI API key
+
+# Astraflow Settings (OpenAI-compatible, 200+ models — https://astraflow.ucloud-global.com)
+# Global endpoint
+ASTRAFLOW_API_KEY="your-astraflow-api-key"
+ASTRAFLOW_BASE_URL=https://api-us-ca.umodelverse.ai/v1
+# China endpoint
+ASTRAFLOW_CN_API_KEY="your-astraflow-cn-api-key"
+ASTRAFLOW_CN_BASE_URL=https://api.modelverse.cn/v1
 DEFAULT_LLM_MODEL=gpt-4o-mini
 DEFAULT_LLM_TEMPERATURE=0.2
 SESSION_NAMING_ENABLED=true

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -147,6 +147,12 @@ class Settings:
 
         # LangGraph Configuration
         self.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+
+        # Astraflow Configuration (OpenAI-compatible — https://astraflow.ucloud-global.com)
+        self.ASTRAFLOW_API_KEY = os.getenv("ASTRAFLOW_API_KEY", "")
+        self.ASTRAFLOW_BASE_URL = os.getenv("ASTRAFLOW_BASE_URL", "https://api-us-ca.umodelverse.ai/v1")
+        self.ASTRAFLOW_CN_API_KEY = os.getenv("ASTRAFLOW_CN_API_KEY", "")
+        self.ASTRAFLOW_CN_BASE_URL = os.getenv("ASTRAFLOW_CN_BASE_URL", "https://api.modelverse.cn/v1")
         self.DEFAULT_LLM_MODEL = os.getenv("DEFAULT_LLM_MODEL", "gpt-5-mini")
         self.SESSION_NAMING_ENABLED = os.getenv("SESSION_NAMING_ENABLED", "true").lower() == "true"
         self.DEFAULT_LLM_TEMPERATURE = float(os.getenv("DEFAULT_LLM_TEMPERATURE", "0.2"))

--- a/app/services/llm/registry.py
+++ b/app/services/llm/registry.py
@@ -18,6 +18,8 @@ from app.core.logging import logger
 
 _TOKEN_LIMIT: Dict[str, Any] = {"max_completion_tokens": settings.MAX_TOKENS}
 _API_KEY = SecretStr(settings.OPENAI_API_KEY)
+_ASTRAFLOW_API_KEY = SecretStr(settings.ASTRAFLOW_API_KEY)
+_ASTRAFLOW_CN_API_KEY = SecretStr(settings.ASTRAFLOW_CN_API_KEY)
 
 
 class LLMRegistry:
@@ -28,6 +30,30 @@ class LLMRegistry:
     """
 
     LLMS: List[Dict[str, Any]] = [
+        # ---------------------------------------------------------------------------
+        # Astraflow — OpenAI-compatible platform with 200+ models (https://astraflow.ucloud-global.com)
+        # Set DEFAULT_LLM_MODEL=astraflow/default (global) or astraflow-cn/default (China)
+        # to route all traffic through Astraflow instead of OpenAI.
+        # Any model slug supported by Astraflow can be used at call-time via kwargs.
+        # ---------------------------------------------------------------------------
+        {
+            "name": "astraflow/default",
+            "llm": ChatOpenAI(
+                model="gpt-4o-mini",
+                api_key=_ASTRAFLOW_API_KEY,
+                base_url=settings.ASTRAFLOW_BASE_URL,
+                model_kwargs=_TOKEN_LIMIT,
+            ),
+        },
+        {
+            "name": "astraflow-cn/default",
+            "llm": ChatOpenAI(
+                model="gpt-4o-mini",
+                api_key=_ASTRAFLOW_CN_API_KEY,
+                base_url=settings.ASTRAFLOW_CN_BASE_URL,
+                model_kwargs=_TOKEN_LIMIT,
+            ),
+        },
         {
             "name": "gpt-5-mini",
             "llm": ChatOpenAI(
@@ -93,6 +119,21 @@ class LLMRegistry:
 
         if kwargs:
             logger.debug("creating_llm_with_custom_args", model_name=model_name, custom_args=list(kwargs.keys()))
+            # Route Astraflow models through the correct base URL and API key
+            if model_name.startswith("astraflow-cn"):
+                return ChatOpenAI(
+                    model=kwargs.pop("model", model_name),
+                    api_key=_ASTRAFLOW_CN_API_KEY,
+                    base_url=settings.ASTRAFLOW_CN_BASE_URL,
+                    **kwargs,
+                )
+            if model_name.startswith("astraflow"):
+                return ChatOpenAI(
+                    model=kwargs.pop("model", model_name),
+                    api_key=_ASTRAFLOW_API_KEY,
+                    base_url=settings.ASTRAFLOW_BASE_URL,
+                    **kwargs,
+                )
             return ChatOpenAI(model=model_name, api_key=_API_KEY, **kwargs)
 
         logger.debug("using_default_llm_instance", model_name=model_name)


### PR DESCRIPTION
## Summary

Adds [Astraflow](https://astraflow.ucloud-global.com) by UCloud as an OpenAI-compatible LLM provider alongside the existing OpenAI models.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models, available via a global endpoint and a China endpoint. Because it is API-compatible with OpenAI, integration requires only setting `base_url` + `api_key` on `ChatOpenAI` — no new SDK or subpackage needed.

## Changes

### `.env.example`
- Documents `ASTRAFLOW_API_KEY` (global endpoint) and `ASTRAFLOW_CN_API_KEY` (China endpoint).

### `app/core/config.py`
- Reads `ASTRAFLOW_API_KEY`, `ASTRAFLOW_CN_API_KEY`, `ASTRAFLOW_BASE_URL`, and `ASTRAFLOW_CN_BASE_URL` from the environment, with the official default base URLs pre-filled.

### `app/services/llm/registry.py`
- Adds two Astraflow entries to `LLMRegistry.LLMS`:
  - `astraflow/default` — global endpoint, uses `ASTRAFLOW_API_KEY`
  - `astraflow-cn/default` — China endpoint, uses `ASTRAFLOW_CN_API_KEY`
- Both entries reuse `ChatOpenAI` (already a dependency) with the Astraflow `base_url` so no new packages are required.
- The `get()` method already supports per-call overrides, so any Astraflow model slug can be passed at call-time via `kwargs`.

## Usage

```bash
# .env
ASTRAFLOW_API_KEY=your-global-key
DEFAULT_LLM_MODEL=astraflow/default
```

Or for the China endpoint:
```bash
ASTRAFLOW_CN_API_KEY=your-cn-key
DEFAULT_LLM_MODEL=astraflow-cn/default
```

Sign up at https://astraflow.ucloud-global.com (global) or https://astraflow.ucloud.cn (China).