### PR TITLE
Install Docker dependencies from uv.lock to prevent version drift

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,14 +13,14 @@ API_V1_STR=/api/v1
 ALLOWED_ORIGINS="http://localhost:3000,http://localhost:8000"
 
 # Langfuse Settings
-LANGFUSE_TRACING_ENABLED=true
+LANGFUSE_TRACING_ENABLED=false
 LANGFUSE_PUBLIC_KEY="your-langfuse-public-key"
 LANGFUSE_SECRET_KEY="your-langfuse-secret-key"
 LANGFUSE_HOST=https://cloud.langfuse.com
 
 # LLM Settings
 OPENAI_API_KEY="your-llm-api-key" # e.g. OpenAI API key
-DEFAULT_LLM_MODEL=gpt-4o-mini
+DEFAULT_LLM_MODEL=gpt-5-mini
 DEFAULT_LLM_TEMPERATURE=0.2
 SESSION_NAMING_ENABLED=true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,13 @@ RUN apt-get update && apt-get install -y \
     && pip install uv \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy pyproject.toml first to leverage Docker cache
-COPY pyproject.toml .
-RUN uv venv && . .venv/bin/activate && uv pip install -e .
+# Install locked dependencies first (cached unless pyproject.toml / uv.lock change)
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-install-project
 
-# Copy the application
+# Copy the application and install the project itself against the locked deps
 COPY . .
+RUN uv sync --frozen
 
 # Make entrypoint script executable - do this before changing user
 RUN chmod +x /app/scripts/docker-entrypoint.sh


### PR DESCRIPTION
The Docker build installed dependencies with `uv pip install -e .` from `pyproject.toml` alone, ignoring `uv.lock`. This re-resolved `mem0ai>=1.0.0` to 2.0.2, whose `AsyncMemory.from_config` is synchronous, while the locked 1.0.0 is async — crashing startup with `TypeError: object AsyncMemory can't be used in 'await' expression`. Local and CI were unaffected since both honor the lockfile.

This switches the Dockerfile to `uv sync --frozen` against `pyproject.toml` and `uv.lock`, so the image installs the same mem0 1.0.0 as everywhere else and builds become reproducible. No application code changes; the existing `await` is correct for the locked version. Verified by rebuilding with `--no-cache`, confirming `mem0ai==1.0.0` in the image, and a clean startup through `make docker-up`.

Closes https://github.com/wassim249/fastapi-langgraph-agent-production-ready-template/issues/78
Closes https://github.com/wassim249/fastapi-langgraph-agent-production-ready-template/issues/74

Btw, I also defaults Langfuse tracing to off and sets a valid `DEFAULT_LLM_MODEL`, so a fresh clone following the getting-started guide boots cleanly without requiring Langfuse credentials.

