### PR TITLE
Don't let Langfuse auth failures crash startup

### DIFF
--- a/app/core/observability.py
+++ b/app/core/observability.py
@@ -9,6 +9,10 @@ from app.core.logging import logger
 
 def langfuse_init():
     """Initialize Langfuse."""
+    if not settings.LANGFUSE_TRACING_ENABLED:
+        logger.debug("langfuse_tracing_disabled")
+        return
+
     langfuse = Langfuse(
         tracing_enabled=settings.LANGFUSE_TRACING_ENABLED,
         public_key=settings.LANGFUSE_PUBLIC_KEY,
@@ -18,10 +22,13 @@ def langfuse_init():
         debug=settings.DEBUG,
     )
 
-    if langfuse.auth_check():
-        logger.debug("langfuse_auth_success")
-    else:
-        logger.debug("langfuse_auth_failure")
+    try:
+        if langfuse.auth_check():
+            logger.debug("langfuse_auth_success")
+        else:
+            logger.warning("langfuse_auth_failure")
+    except Exception:
+        logger.exception("langfuse_auth_check_failed")
 
 
 def get_langfuse_callback_handler() -> CallbackHandler:


### PR DESCRIPTION
Closes https://github.com/wassim249/fastapi-langgraph-agent-production-ready-template/issues/82

`langfuse_init()` runs at import time from `main.py`, and it always built the Langfuse client and called `auth_check()` regardless of configuration. In the current Langfuse version `auth_check()` raises `UnauthorizedError` instead of
returning `False` when keys are missing or invalid, so the exception propagated up through uvicorn's `config.load_app()` and the app failed to start. This bites the default Docker dev setup, where `.env.development` ships with `LANGFUSE_TRACING_ENABLED=false` and empty keys.

The fix guards on the flag. Ehen tracing is disabled, `langfuse_init()` returns early without constructing a client or hitting the network — and wraps the auth check so a failure is logged (`warning`/`exception`) rather than raised. The result
is that tracing stays a pure observability concern that can never take down the API: misconfigured or absent keys degrade to "no tracing" instead of a crash. No behavior change when keys are valid; the callback handler is untouched since it does no auth work on construction.
