### PR TITLE
fix: deploy workflow never ran due to secrets context in step-level if

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,9 +12,11 @@ jobs:
   build-and-push:
     name: Build and push to Docker Hub
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install utilities
         run: |
@@ -25,22 +27,19 @@ jobs:
         id: sanitize
         run: |
           REPO_NAME=$(echo "${{ github.event.repository.name }}" | sed 's/^\///' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g')
-          echo "REPO_NAME=${REPO_NAME}" >> $GITHUB_ENV
+          echo "REPO_NAME=${REPO_NAME}" >> "$GITHUB_ENV"
 
       - name: Build Image
         run: |
           make docker-build ENV=production
 
       - name: Log in to Docker Hub
-        if: ${{ secrets.DOCKER_USERNAME != '' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         run: |
-          echo ${{ secrets.DOCKER_PASSWORD }} | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login --username "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Push Image
-        if: ${{ secrets.DOCKER_USERNAME != '' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         run: |
           docker tag fastapi-langgraph-template:production ${{ secrets.DOCKER_USERNAME }}/${{ env.REPO_NAME }}:production
           docker push ${{ secrets.DOCKER_USERNAME }}/${{ env.REPO_NAME }}:production
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Follow-up to #76 / #77. Merging #76 fixed the `make docker-build-env` target name, but the **Build and push to Docker Hub** job still fails instantly (0s, every run since May) because the workflow file itself doesn't validate: the `secrets` context is not allowed in step-level `if` conditions. JFer11's #77 investigation covered the make target; this is the second, masked bug in the same file.

actionlint pinpoints it:

```
.github/workflows/deploy.yaml:35:17: context "secrets" is not allowed here. available contexts are
"env", "github", "inputs", "job", "matrix", "needs", "runner", "steps", "strategy", "vars"
```

Changes:
- Expose `DOCKER_USERNAME` through job-level `env` and gate the login/push steps on `env.DOCKER_USERNAME` instead of `secrets.*`.
- Also gate login/push on `github.event_name == 'push'` so `pull_request` runs build the image but never push to Docker Hub.
- `actions/checkout` v3 → v4, quote `$GITHUB_ENV` and the docker login args (remaining actionlint/shellcheck findings).

`actionlint` now passes with zero findings. The deploy check on this very PR is the end-to-end proof: if the file parses, the build step actually runs for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)