### PR TITLE
fix: bound in-memory cache with LRU and centralize background task refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ wheels/
 
 # Reports
 evals/reports/
+
+# pycharm
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-DOCKER_COMPOSE ?= docker-compose
+DOCKER_COMPOSE ?= docker compose
 ENV            ?= development
 VALID_ENVS     := development staging production test
 

--- a/app/core/cache.py
+++ b/app/core/cache.py
@@ -6,6 +6,7 @@ Otherwise, falls back to a simple in-memory TTL cache.
 
 import hashlib
 import time
+from collections import OrderedDict
 from typing import (
     TYPE_CHECKING,
     Awaitable,
@@ -33,20 +34,26 @@ else:
 
 
 class InMemoryCacheService:
-    """Simple in-memory TTL cache fallback when Valkey is not available."""
+    """Simple in-memory TTL cache fallback when Valkey is not available.
 
-    def __init__(self, default_ttl: int = 60):
+    Bounded by ``max_size`` with LRU eviction so high-cardinality keys that are
+    written but never re-read cannot grow the process memory without limit.
+    """
+
+    def __init__(self, default_ttl: int = 60, max_size: int = 10000):
         """Initialize in-memory cache.
 
         Args:
             default_ttl: Default time-to-live in seconds for cache entries.
+            max_size: Maximum number of entries retained before LRU eviction.
         """
-        self._cache: dict[str, tuple[float, str]] = {}
+        self._cache: OrderedDict[str, tuple[float, str]] = OrderedDict()
         self._default_ttl = default_ttl
+        self._max_size = max_size
 
     async def initialize(self) -> None:
         """No-op for in-memory cache."""
-        logger.info("cache_initialized", backend="in_memory", ttl=self._default_ttl)
+        logger.info("cache_initialized", backend="in_memory", ttl=self._default_ttl, max_size=self._max_size)
 
     async def get(self, key: str) -> Optional[str]:
         """Get a value from cache.
@@ -64,6 +71,8 @@ class InMemoryCacheService:
         if time.monotonic() > expires_at:
             del self._cache[key]
             return None
+        # Mark as most-recently-used for LRU ordering.
+        self._cache.move_to_end(key)
         return value
 
     async def set(self, key: str, value: str, ttl: Optional[int] = None) -> None:
@@ -76,6 +85,10 @@ class InMemoryCacheService:
         """
         expires_at = time.monotonic() + (ttl or self._default_ttl)
         self._cache[key] = (expires_at, value)
+        self._cache.move_to_end(key)
+        # Evict least-recently-used entries once the cache is over capacity.
+        while len(self._cache) > self._max_size:
+            self._cache.popitem(last=False)
 
     async def delete(self, key: str) -> None:
         """Delete a value from cache.
@@ -191,7 +204,7 @@ def _create_cache_service() -> InMemoryCacheService | ValkeyCacheService:
             hint="install with: uv add redis --optional cache",
         )
 
-    return InMemoryCacheService(default_ttl=ttl)
+    return InMemoryCacheService(default_ttl=ttl, max_size=settings.CACHE_MAX_ITEMS)
 
 
 def cache_key(prefix: str, *parts: str) -> str:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -189,6 +189,7 @@ class Settings:
         self.VALKEY_PASSWORD = os.getenv("VALKEY_PASSWORD", "")
         self.VALKEY_MAX_CONNECTIONS = int(os.getenv("VALKEY_MAX_CONNECTIONS", "20"))
         self.CACHE_TTL_SECONDS = int(os.getenv("CACHE_TTL_SECONDS", "60"))
+        self.CACHE_MAX_ITEMS = int(os.getenv("CACHE_MAX_ITEMS", "10000"))
 
         # Rate Limiting Configuration
         self.RATE_LIMIT_DEFAULT = parse_list_from_env("RATE_LIMIT_DEFAULT", ["200 per day", "50 per hour"])

--- a/app/core/langgraph/graph.py
+++ b/app/core/langgraph/graph.py
@@ -61,6 +61,7 @@ from app.utils import (
     extract_text_content,
     prepare_messages,
     process_llm_response,
+    spawn_background_task,
 )
 
 PostgresConnPool = AsyncConnectionPool[AsyncConnection[DictRow]]
@@ -335,7 +336,7 @@ class LangGraphAgent:
                 return [Message(role="assistant", content=str(interrupt_value))]
 
             openai_msgs = cast(list[dict], convert_to_openai_messages(response["messages"]))
-            asyncio.create_task(memory_service.add(user_id, openai_msgs, config.get("metadata")))
+            spawn_background_task(memory_service.add(user_id, openai_msgs, config.get("metadata")))
             return self.__process_messages(response["messages"])
         except GraphInterrupt:
             state = await graph.aget_state(config)
@@ -412,7 +413,7 @@ class LangGraphAgent:
                 yield str(interrupt_value)
             elif state.values and "messages" in state.values:
                 openai_msgs = cast(list[dict], convert_to_openai_messages(state.values["messages"]))
-                asyncio.create_task(memory_service.add(user_id, openai_msgs, config.get("metadata")))
+                spawn_background_task(memory_service.add(user_id, openai_msgs, config.get("metadata")))
         except GraphInterrupt:
             state = await graph.aget_state(config)
             interrupt_value = state.tasks[0].interrupts[0].value if state.tasks else "Waiting for input."

--- a/app/services/session_naming.py
+++ b/app/services/session_naming.py
@@ -9,8 +9,6 @@ On the first message of a new session this module:
      structured output to generate a proper title and overwrites the placeholder.
 """
 
-import asyncio
-
 from langchain_core.messages import HumanMessage, SystemMessage
 from sqlmodel import (
     Session as DBSession,
@@ -25,10 +23,9 @@ from app.models.session import Session as ChatSession
 from app.schemas.chat import SessionTitle
 from app.services.database import database_service
 from app.services.llm import llm_service
+from app.utils import spawn_background_task
 
 _PLACEHOLDER_MAX = 40
-
-_background_tasks: set[asyncio.Task] = set()
 
 
 def _build_placeholder(user_message: str) -> str:
@@ -86,6 +83,4 @@ def maybe_name_session(session_id: str, session_name: str, messages: list) -> No
     if not first_user_msg:
         return
     if _claim_session(session_id, _build_placeholder(first_user_msg)):
-        task = asyncio.create_task(_persist_session_name(session_id, first_user_msg))
-        _background_tasks.add(task)
-        task.add_done_callback(_background_tasks.discard)
+        spawn_background_task(_persist_session_name(session_id, first_user_msg))

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -6,5 +6,12 @@ from .graph import (
     prepare_messages,
     process_llm_response,
 )
+from .tasks import spawn_background_task
 
-__all__ = ["dump_messages", "extract_text_content", "prepare_messages", "process_llm_response"]
+__all__ = [
+    "dump_messages",
+    "extract_text_content",
+    "prepare_messages",
+    "process_llm_response",
+    "spawn_background_task",
+]

--- a/app/utils/tasks.py
+++ b/app/utils/tasks.py
@@ -1,0 +1,23 @@
+"""Helpers for managing fire-and-forget asyncio tasks."""
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any
+
+_background_tasks: set[asyncio.Task] = set()
+
+
+def spawn_background_task(coro: Coroutine[Any, Any, Any]) -> asyncio.Task:
+    """Schedule a fire-and-forget coroutine while retaining a strong reference.
+
+    Args:
+        coro: The coroutine to run in the background.
+
+    Returns:
+        The scheduled task. Callers may ignore it; the reference is held
+        internally until the task completes.
+    """
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task


### PR DESCRIPTION
- Add CACHE_MAX_ITEMS config with default 10000
- Use OrderedDict in InMemoryCacheService for LRU eviction
- Introduce app.utils.tasks.spawn_background_task helper to keep strong references to fire-and-forget asyncio tasks
- Replace raw asyncio.create_task calls in graph and session naming with the shared helper to prevent premature GC
- Switch Makefile from docker-compose to docker compose
- Ignore .idea/ in gitignore