### PR TITLE
fix: fail closed on missing or placeholder environment secrets

### DIFF
--- a/scripts/set_env.sh
+++ b/scripts/set_env.sh
@@ -67,29 +67,39 @@ if [ -f "$ENV_FILE" ]; then
 
     echo -e "${GREEN}Successfully loaded environment variables from $ENV_FILE${NC}"
 else
-    echo -e "${YELLOW}Warning: $ENV_FILE not found. Creating from .env.example...${NC}"
+    if [[ "$ENV" == "development" ]]; then
+        echo -e "${YELLOW}Warning: $ENV_FILE not found. Creating from .env.example...${NC}"
 
-    EXAMPLE_FILE="$PROJECT_ROOT/.env.example"
-    if [ -f "$EXAMPLE_FILE" ]; then
-        cp "$EXAMPLE_FILE" "$ENV_FILE"
-        echo -e "${GREEN}Created $ENV_FILE from template.${NC}"
-        echo -e "${PURPLE}Please update it with your configuration.${NC}"
+        EXAMPLE_FILE="$PROJECT_ROOT/.env.example"
+        if [ -f "$EXAMPLE_FILE" ]; then
+            cp "$EXAMPLE_FILE" "$ENV_FILE"
+            echo -e "${GREEN}Created $ENV_FILE from template.${NC}"
+            echo -e "${PURPLE}Please update it with your configuration before starting the app.${NC}"
 
-        # Export all environment variables from the new file
-        set -a
-        source "$ENV_FILE"
-        set +a
+            # Export all environment variables from the new file
+            set -a
+            source "$ENV_FILE"
+            set +a
 
-        validate_jwt_secret_key "${JWT_SECRET_KEY:-}" || return 1
-
-        echo -e "${GREEN}Successfully loaded environment variables from new $ENV_FILE${NC}"
+            echo -e "${GREEN}Successfully loaded environment variables from new $ENV_FILE${NC}"
+        else
+            echo -e "${RED}Error: .env.example not found at $EXAMPLE_FILE${NC}"
+            return 1
+        fi
     else
-        echo -e "${RED}Error: .env.example not found at $EXAMPLE_FILE${NC}"
+        echo -e "${RED}Error: $ENV_FILE not found. Refusing to start $ENV with template defaults.${NC}"
+        echo -e "${PURPLE}Create $ENV_FILE from .env.example, then set real secrets before retrying.${NC}"
         return 1
     fi
 fi
 
 validate_jwt_secret_key "${JWT_SECRET_KEY:-}" || return 1
+
+if [[ "$ENV" != "development" && "${APP_ENV:-}" != "$ENV" ]]; then
+    echo -e "${RED}Error: APP_ENV resolved to '${APP_ENV:-unset}' while '$ENV' was requested.${NC}"
+    echo -e "${PURPLE}Fix the environment file so APP_ENV matches the requested environment.${NC}"
+    return 1
+fi
 
 # Print current environment
 echo -e "\n${GREEN}======= ENVIRONMENT SUMMARY =======${NC}"


### PR DESCRIPTION
## Problem

The production/staging bootstrap path is fail-open when the environment-specific file is missing.

`scripts/set_env.sh` currently copies `.env.example` into the requested env file and sources it automatically. The template contains development-oriented values, including:

- `APP_ENV=development`
- `DEBUG=true`
- `JWT_SECRET_KEY="your-jwt-secret-key"`

That means a first-time `production` or `staging` launch can silently start in development mode with a publicly known JWT signing key.

## Security impact

If this happens on a network-reachable deployment, anyone who knows the placeholder JWT secret can forge HS256 user/session tokens and access authenticated endpoints. In practice that can allow impersonation, session enumeration, and chat history access/modification.

## Fix

This patch makes the startup path fail closed:

- refuse to auto-create missing non-development env files from `.env.example`
- reject empty or placeholder `JWT_SECRET_KEY` values in `scripts/set_env.sh`
- ensure `APP_ENV` matches the requested environment during bootstrap
- add a runtime guard in `app/core/config.py` so direct `uvicorn` launches also reject placeholder/missing JWT secrets

## Test Plan

- [ ] Remove `.env.production`, then run `source scripts/set_env.sh production` → startup is blocked
- [ ] Set `JWT_SECRET_KEY=your-jwt-secret-key` and launch → startup is blocked
- [ ] Set `APP_ENV=production` with a real random `JWT_SECRET_KEY` → startup proceeds normally
- [ ] Development setups with a real JWT secret continue to work as before

## Security Note

Severity: **High**. Private vulnerability reporting appears disabled on this repository, so this patch is prepared as a direct PR for maintainer review.
