### PR TITLE
fix: compare login passwords verbatim

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -218,7 +218,6 @@ async def login(
     try:
         # Sanitize inputs
         email = sanitize_string(email)
-        password = sanitize_string(password)
         grant_type = sanitize_string(grant_type)
 
         # Verify grant type


### PR DESCRIPTION
<!-- failsafe-scan-id: cmshnfdyr0049nt011ueh5f50 -->
## Summary
This patch removes HTML escaping from the login password path so registration and login both operate on the same raw secret.

## Impact
Before this change, passwords containing `<`, `>`, `&`, or `"` were hashed raw at registration time but escaped before bcrypt verification during login. That made affected accounts impossible to log into even when the user supplied the exact password they registered.

## Changes
- stop applying `sanitize_string()` to the submitted password in `POST /api/v1/auth/login`
- keep sanitization for `email` and `grant_type` unchanged

## Validation
- source-level regression check confirmed `password = sanitize_string(password)` is gone while `email` and `grant_type` sanitization remain
- helper check confirmed `html.escape()` mutates the affected password shapes (`P@ssw0rd<1>`, `Qoute"&Amp<3`), which is why the old login path broke verification

## Disclosure notes
- finding id: FIND-002
- pool: hardening
- this is prepared as a PR-only fix; nothing has been submitted publicly
