### PR TITLE
fix: startup and config bugs, and move the model registry to gpt-5.6-luna

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 
 # LLM Settings
 OPENAI_API_KEY="your-llm-api-key" # e.g. OpenAI API key
-DEFAULT_LLM_MODEL=gpt-5-mini
+DEFAULT_LLM_MODEL=gpt-5.6-luna
 
 # Atlas Cloud (OpenAI-compatible) — alternative to OpenAI, access 59+ LLMs with one key
 # Get your free key at: https://www.atlascloud.ai/console/coding-plan

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A production-ready template for building AI agent backends with FastAPI and Lang
 
 [**Atlas Cloud**](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=fastapi-langgraph-agent-production-ready-template) provides an **OpenAI-compatible LLM API** that integrates seamlessly into this FastAPI + LangGraph template — no code changes to your agent graph needed. Just swap `OPENAI_BASE_URL` and `OPENAI_API_KEY` to access **DeepSeek, Qwen, GLM, Kimi, MiniMax, Gemini, Claude, GPT** and more through a single unified endpoint.
 
-The `LLMRegistry` in this template uses `langchain_openai.ChatOpenAI` — Atlas Cloud is wire-compatible, so you get instant access to 59+ curated reasoning models without touching any LangGraph logic.
+The `LLMRegistry` in this template uses `langchain_openai.ChatOpenAI` — Atlas Cloud is wire-compatible, so you get instant access to 130+ curated models without touching any LangGraph logic.
 
 ### Quick Setup
 
@@ -49,72 +49,45 @@ llm = ChatOpenAI(
 This works as a drop-in replacement anywhere `ChatOpenAI` is used in your LangGraph agent — including the `LLMRegistry`, the circular fallback service, and mem0 long-term memory.
 
 <details>
-<summary>📋 Full model catalog (59 LLMs available)</summary>
+<summary>📋 Model catalog — a current selection (136 available in total)</summary>
 
 | Model ID | Provider |
 |---|---|
-| `deepseek-ai/DeepSeek-V3-0324` | DeepSeek |
-| `deepseek-ai/deepseek-r1-0528` | DeepSeek |
-| `deepseek-ai/DeepSeek-V3.1` | DeepSeek |
-| `deepseek-ai/DeepSeek-V3.1-Terminus` | DeepSeek |
-| `deepseek-ai/DeepSeek-V3.2-Exp` | DeepSeek |
-| `deepseek-ai/deepseek-v3.2` | DeepSeek |
-| `qwen/qwen3-32b` | Alibaba Qwen |
-| `qwen/qwen3-8b` | Alibaba Qwen |
-| `qwen/qwen3-235b-a22b-thinking-2507` | Alibaba Qwen |
-| `qwen/qwen3-30b-a3b` | Alibaba Qwen |
-| `qwen/qwen3-30b-a3b-thinking-2507` | Alibaba Qwen |
-| `Qwen/Qwen3-Coder` | Alibaba Qwen |
-| `Qwen/Qwen3-235B-A22B-Instruct-2507` | Alibaba Qwen |
-| `Qwen/Qwen3-Next-80B-A3B-Instruct` | Alibaba Qwen |
-| `Qwen/Qwen3-Next-80B-A3B-Thinking` | Alibaba Qwen |
-| `Qwen/Qwen3-30B-A3B-Instruct-2507` | Alibaba Qwen |
-| `Qwen/Qwen3-VL-235B-A22B-Instruct` | Alibaba Qwen |
-| `moonshotai/Kimi-K2-Instruct` | Moonshot AI |
-| `moonshotai/Kimi-K2-Instruct-0905` | Moonshot AI |
-| `moonshotai/Kimi-K2-Thinking` | Moonshot AI |
-| `moonshotai/kimi-k2.5` | Moonshot AI |
-| `zai-org/GLM-4.6` | Zhipu AI |
-| `zai-org/glm-4.7` | Zhipu AI |
-| `MiniMaxAI/MiniMax-M2` | MiniMax |
-| `minimaxai/minimax-m2.1` | MiniMax |
-| `google/gemini-2.5-flash` | Google |
-| `google/gemini-2.5-flash-preview-202509` | Google |
-| `google/gemini-2.5-flash-lite` | Google |
-| `google/gemini-2.5-flash-lite-preview-202509` | Google |
-| `google/gemini-2.5-pro` | Google |
-| `google/gemini-3-flash-preview` | Google |
-| `google/gemini-2.0-flash` | Google |
-| `google/gemini-2.0-flash-lite` | Google |
-| `openai/gpt-5.1` | OpenAI |
-| `openai/gpt-5.1-chat` | OpenAI |
-| `openai/gpt-5.1-codex` | OpenAI |
-| `openai/gpt-5.1-codex-mini` | OpenAI |
-| `openai/gpt-5.1-codex-max` | OpenAI |
-| `openai/gpt-4o` | OpenAI |
-| `openai/gpt-4o-mini` | OpenAI |
-| `openai/gpt-4.1` | OpenAI |
-| `openai/gpt-4.1-mini` | OpenAI |
-| `openai/gpt-4.1-nano` | OpenAI |
-| `openai/o1` | OpenAI |
-| `openai/o3` | OpenAI |
-| `openai/o3-mini` | OpenAI |
-| `openai/o4-mini` | OpenAI |
-| `openai/o3-pro` | OpenAI |
-| `openai/gpt-5` | OpenAI |
-| `openai/gpt-5-chat` | OpenAI |
-| `openai/gpt-5-codex` | OpenAI |
-| `openai/gpt-5-mini` | OpenAI |
-| `openai/gpt-5-nano` | OpenAI |
-| `openai/gpt-5-pro` | OpenAI |
+| `openai/gpt-5.6-luna` | OpenAI |
+| `openai/gpt-5.6-sol` | OpenAI |
+| `openai/gpt-5.6-terra` | OpenAI |
+| `openai/gpt-5.5` | OpenAI |
+| `openai/gpt-5.4` | OpenAI |
+| `openai/gpt-5.4-mini` | OpenAI |
+| `openai/gpt-5.4-nano` | OpenAI |
+| `openai/gpt-5.3-codex` | OpenAI |
 | `openai/gpt-5.2` | OpenAI |
-| `openai/gpt-5.2-chat` | OpenAI |
-| `anthropic/claude-sonnet-4-20250514` | Anthropic |
+| `anthropic/claude-opus-5` | Anthropic |
+| `anthropic/claude-sonnet-5` | Anthropic |
+| `anthropic/claude-opus-4.8` | Anthropic |
+| `anthropic/claude-sonnet-4.6` | Anthropic |
 | `anthropic/claude-haiku-4.5-20251001` | Anthropic |
-| `anthropic/claude-sonnet-4.5-20250929` | Anthropic |
-| `anthropic/claude-opus-4.1-20250805` | Anthropic |
-| `anthropic/claude-opus-4-20250514` | Anthropic |
-| `anthropic/claude-opus-4.5-20251101` | Anthropic |
+| `google/gemini-3.5-flash` | Google |
+| `google/gemini-3.1-pro-preview` | Google |
+| `google/gemini-3.1-flash-lite` | Google |
+| `google/gemini-2.5-pro` | Google |
+| `deepseek-ai/deepseek-v4-pro` | DeepSeek |
+| `deepseek-ai/deepseek-v4-flash` | DeepSeek |
+| `qwen/qwen3.8-max` | Alibaba Qwen |
+| `qwen/qwen3.7-plus` | Alibaba Qwen |
+| `qwen/qwen3.5-plus` | Alibaba Qwen |
+| `moonshotai/kimi-k3` | Moonshot AI |
+| `moonshotai/kimi-k2.7-code` | Moonshot AI |
+| `zai-org/glm-5.2` | Zhipu AI |
+| `zai-org/glm-5.1` | Zhipu AI |
+| `zai-org/glm-5` | Zhipu AI |
+| `minimaxai/minimax-m3` | MiniMax |
+| `minimaxai/minimax-m2.7` | MiniMax |
+| `xai/grok-4.6` | xAI |
+| `xai/grok-4.5` | xAI |
+| `bytedance/doubao-seed-2.1-pro-260628` | ByteDance |
+| `xiaomi/mimo-v2.5-pro` | Xiaomi |
+| `tencent/hy3` | Tencent |
 
 [View live model list →](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=fastapi-langgraph-agent-production-ready-template)
 

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,4 +1,4 @@
-"""${message | trim}."""
+"""${message | trim}.
 
 Revision ID: ${up_revision}
 Revises: ${down_revision | comma,n}

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -33,7 +33,7 @@ from app.schemas.auth import (
     UserCreate,
     UserResponse,
 )
-from app.services.database import DatabaseService
+from app.services.database import database_service
 from app.utils.auth import (
     create_access_token,
     verify_token,
@@ -46,7 +46,9 @@ from app.utils.sanitization import (
 
 router = APIRouter()
 security = HTTPBearer()
-db_service = DatabaseService()
+# Reuse the shared instance: DatabaseService.__init__ builds its own engine, so a
+# second instance here meant two independent connection pools.
+db_service = database_service
 
 
 async def get_current_user(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -157,7 +157,7 @@ class Settings:
 
         # LangGraph Configuration
         self.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
-        self.DEFAULT_LLM_MODEL = os.getenv("DEFAULT_LLM_MODEL", "gpt-5-mini")
+        self.DEFAULT_LLM_MODEL = os.getenv("DEFAULT_LLM_MODEL", "gpt-5.6-luna")
         self.SESSION_NAMING_ENABLED = os.getenv("SESSION_NAMING_ENABLED", "true").lower() == "true"
         self.DEFAULT_LLM_TEMPERATURE = float(os.getenv("DEFAULT_LLM_TEMPERATURE", "0.2"))
         self.MAX_TOKENS = int(os.getenv("MAX_TOKENS", "2000"))

--- a/app/core/langgraph/graph.py
+++ b/app/core/langgraph/graph.py
@@ -41,10 +41,7 @@ from psycopg.rows import (
 )
 from psycopg_pool import AsyncConnectionPool
 
-from app.core.config import (
-    Environment,
-    settings,
-)
+from app.core.config import settings
 from app.core.langgraph.tools import tools
 from app.core.logging import logger
 from app.core.metrics import llm_inference_duration_seconds
@@ -87,12 +84,14 @@ class LangGraphAgent:
             environment=settings.ENVIRONMENT.value,
         )
 
-    async def _get_connection_pool(self) -> Optional[PostgresConnPool]:
+    async def _get_connection_pool(self) -> PostgresConnPool:
         """Get a PostgreSQL connection pool using environment-specific settings.
 
         Returns:
-            AsyncConnectionPool or None when the pool fails to initialise in
-            production (the app keeps running in a degraded mode).
+            AsyncConnectionPool: The open connection pool.
+
+        Raises:
+            Exception: If the pool cannot be created, in every environment.
         """
         if self._connection_pool is None:
             try:
@@ -119,11 +118,12 @@ class LangGraphAgent:
                 await self._connection_pool.open()
                 logger.info("connection_pool_created", max_size=max_size, environment=settings.ENVIRONMENT.value)
             except Exception as e:
-                logger.error("connection_pool_creation_failed", error=str(e), environment=settings.ENVIRONMENT.value)
-                # In production, we might want to degrade gracefully
-                if settings.ENVIRONMENT == Environment.PRODUCTION:
-                    logger.warning("continuing_without_connection_pool", environment=settings.ENVIRONMENT.value)
-                    return None
+                logger.exception(
+                    "connection_pool_creation_failed", error=str(e), environment=settings.ENVIRONMENT.value
+                )
+                # Never degrade silently: the checkpointer is the only store for
+                # conversation history and HITL resume state. Serving without it
+                # loses data rather than surfacing an outage.
                 raise e
         return self._connection_pool
 
@@ -211,11 +211,14 @@ class LangGraphAgent:
 
         return Command(update={"messages": outputs}, goto="chat")
 
-    async def create_graph(self) -> Optional[CompiledStateGraph]:
+    async def create_graph(self) -> CompiledStateGraph:
         """Create and configure the LangGraph workflow.
 
         Returns:
-            Optional[CompiledStateGraph]: The configured LangGraph instance or None if init fails
+            CompiledStateGraph: The configured LangGraph instance, always with a checkpointer.
+
+        Raises:
+            Exception: If the graph cannot be built, in every environment.
         """
         if self._graph is None:
             try:
@@ -230,16 +233,10 @@ class LangGraphAgent:
                 graph_builder.set_entry_point("chat")
                 graph_builder.set_finish_point("chat")
 
-                # Get connection pool (may be None in production if DB unavailable)
+                # Raises if the pool cannot be created — no checkpointer, no service.
                 connection_pool = await self._get_connection_pool()
-                if connection_pool:
-                    checkpointer = AsyncPostgresSaver(connection_pool)
-                    await checkpointer.setup()
-                else:
-                    # In production, proceed without checkpointer if needed
-                    checkpointer = None
-                    if settings.ENVIRONMENT != Environment.PRODUCTION:
-                        raise Exception("Connection pool initialization failed")
+                checkpointer = AsyncPostgresSaver(connection_pool)
+                await checkpointer.setup()
 
                 self._graph = graph_builder.compile(
                     checkpointer=checkpointer, name=f"{settings.PROJECT_NAME} Agent ({settings.ENVIRONMENT.value})"
@@ -252,11 +249,7 @@ class LangGraphAgent:
                     has_checkpointer=checkpointer is not None,
                 )
             except Exception as e:
-                logger.error("graph_creation_failed", error=str(e), environment=settings.ENVIRONMENT.value)
-                # In production, we don't want to crash the app
-                if settings.ENVIRONMENT == Environment.PRODUCTION:
-                    logger.warning("continuing_without_graph")
-                    return None
+                logger.exception("graph_creation_failed", error=str(e), environment=settings.ENVIRONMENT.value)
                 raise e
 
         return self._graph
@@ -265,14 +258,11 @@ class LangGraphAgent:
         """Return the compiled graph, creating it on first access.
 
         Raises:
-            RuntimeError: When ``create_graph()`` swallowed an init failure
-                (production-only path) and returned ``None``. Callers can
-                rely on the return being non-``None``.
+            Exception: Propagated from ``create_graph()`` when initialisation
+                fails. Callers can rely on the return being non-``None``.
         """
         if self._graph is None:
             self._graph = await self.create_graph()
-        if self._graph is None:
-            raise RuntimeError("graph initialization failed")
         return self._graph
 
     async def get_response(

--- a/app/core/limiter.py
+++ b/app/core/limiter.py
@@ -11,15 +11,23 @@ so rate limits work correctly across multiple app instances.
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
+from app.core.cache import REDIS_AVAILABLE
 from app.core.config import settings
 from app.core.logging import logger
 
-# Build storage URI for Valkey if configured
+# Build storage URI for Valkey if configured. redis is an optional dependency
+# (the `cache` extra), so fall back to in-memory storage when it is missing
+# rather than letting limits raise ConfigurationError at import time.
 _storage_uri = None
-if settings.VALKEY_HOST:
+if settings.VALKEY_HOST and REDIS_AVAILABLE:
     _password_part = f":{settings.VALKEY_PASSWORD}@" if settings.VALKEY_PASSWORD else ""
     _storage_uri = f"redis://{_password_part}{settings.VALKEY_HOST}:{settings.VALKEY_PORT}/{settings.VALKEY_DB}"
     logger.info("rate_limiter_using_valkey", host=settings.VALKEY_HOST, port=settings.VALKEY_PORT)
+elif settings.VALKEY_HOST:
+    logger.warning(
+        "rate_limiter_valkey_configured_but_redis_missing",
+        hint="install with: uv add redis --optional cache",
+    )
 
 # Initialize rate limiter (uses in-memory storage if no Valkey)
 limiter = Limiter(

--- a/app/services/llm/registry.py
+++ b/app/services/llm/registry.py
@@ -11,14 +11,14 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_openai import ChatOpenAI
 from pydantic import SecretStr
 
-from app.core.config import (
-    Environment,
-    settings,
-)
+from app.core.config import settings
 from app.core.logging import logger
 
-_TOKEN_LIMIT: Dict[str, Any] = {"max_completion_tokens": settings.MAX_TOKENS}
 _API_KEY = SecretStr(settings.OPENAI_API_KEY)
+
+# Every model here is a reasoning model, and the API rejects the classic sampling
+# knobs (`top_p`, `presence_penalty`, `frequency_penalty`) with a 400 once
+# `reasoning` is set. Tune quality with `reasoning.effort` instead.
 
 
 class LLMRegistry:
@@ -28,23 +28,34 @@ class LLMRegistry:
     methods to retrieve them by name with optional argument overrides.
     """
 
+    # Ordered by preference: index 0 is the default and the head of the circular
+    # fallback chain, so it degrades newest -> cheapest.
     LLMS: List[Dict[str, Any]] = [
         {
-            "name": "gpt-5-mini",
+            "name": "gpt-5.6-luna",
             "llm": ChatOpenAI(
-                model="gpt-5-mini",
+                model="gpt-5.6-luna",
                 api_key=_API_KEY,
-                model_kwargs=_TOKEN_LIMIT,
-                reasoning={"effort": "low"},
+                max_completion_tokens=settings.MAX_TOKENS,
+                reasoning={"effort": "medium"},
             ),
         },
         {
             "name": "gpt-5.4",
             "llm": ChatOpenAI(
-                model="gpt-5",
+                model="gpt-5.4",
                 api_key=_API_KEY,
-                model_kwargs=_TOKEN_LIMIT,
+                max_completion_tokens=settings.MAX_TOKENS,
                 reasoning={"effort": "medium"},
+            ),
+        },
+        {
+            "name": "gpt-5.4-mini",
+            "llm": ChatOpenAI(
+                model="gpt-5.4-mini",
+                api_key=_API_KEY,
+                max_completion_tokens=settings.MAX_TOKENS,
+                reasoning={"effort": "low"},
             ),
         },
         {
@@ -52,19 +63,8 @@ class LLMRegistry:
             "llm": ChatOpenAI(
                 model="gpt-5.4-nano",
                 api_key=_API_KEY,
-                model_kwargs=_TOKEN_LIMIT,
+                max_completion_tokens=settings.MAX_TOKENS,
                 reasoning={"effort": "low"},
-            ),
-        },
-        {
-            "name": "gpt-5",
-            "llm": ChatOpenAI(
-                model="gpt-5",
-                api_key=_API_KEY,
-                model_kwargs=_TOKEN_LIMIT,
-                top_p=0.95 if settings.ENVIRONMENT == Environment.PRODUCTION else 0.8,
-                presence_penalty=0.1 if settings.ENVIRONMENT == Environment.PRODUCTION else 0.0,
-                frequency_penalty=0.1 if settings.ENVIRONMENT == Environment.PRODUCTION else 0.0,
             ),
         },
     ]
@@ -93,9 +93,9 @@ class LLMRegistry:
             raise ValueError(f"model '{model_name}' not found in registry. available models: {available}")
 
         if kwargs:
-            # Use the entry's real model id, not its registry name: they differ for
-            # aliases (e.g. "gpt-5.4" is served by "gpt-5"), and passing the name
-            # would send an unknown model to the API.
+            # Take the model id from the entry rather than reusing the registry
+            # name, so a name that ever diverges from its model can't send an
+            # unknown id to the API.
             base_llm = cast(ChatOpenAI, model_entry["llm"])
             logger.debug(
                 "creating_llm_with_custom_args",
@@ -105,7 +105,12 @@ class LLMRegistry:
             )
             # ponytail: carries the token limit but not per-entry `reasoning`;
             # add that here if a caller ever needs to override a reasoning model.
-            return ChatOpenAI(model=base_llm.model_name, api_key=_API_KEY, model_kwargs=_TOKEN_LIMIT, **kwargs)
+            return ChatOpenAI(
+                model=base_llm.model_name,
+                api_key=_API_KEY,
+                max_completion_tokens=settings.MAX_TOKENS,
+                **kwargs,
+            )
 
         logger.debug("using_default_llm_instance", model_name=model_name)
         return model_entry["llm"]

--- a/app/services/llm/registry.py
+++ b/app/services/llm/registry.py
@@ -4,6 +4,7 @@ from typing import (
     Any,
     Dict,
     List,
+    cast,
 )
 
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -92,8 +93,19 @@ class LLMRegistry:
             raise ValueError(f"model '{model_name}' not found in registry. available models: {available}")
 
         if kwargs:
-            logger.debug("creating_llm_with_custom_args", model_name=model_name, custom_args=list(kwargs.keys()))
-            return ChatOpenAI(model=model_name, api_key=_API_KEY, **kwargs)
+            # Use the entry's real model id, not its registry name: they differ for
+            # aliases (e.g. "gpt-5.4" is served by "gpt-5"), and passing the name
+            # would send an unknown model to the API.
+            base_llm = cast(ChatOpenAI, model_entry["llm"])
+            logger.debug(
+                "creating_llm_with_custom_args",
+                model_name=model_name,
+                model=base_llm.model_name,
+                custom_args=list(kwargs.keys()),
+            )
+            # ponytail: carries the token limit but not per-entry `reasoning`;
+            # add that here if a caller ever needs to override a reasoning model.
+            return ChatOpenAI(model=base_llm.model_name, api_key=_API_KEY, model_kwargs=_TOKEN_LIMIT, **kwargs)
 
         logger.debug("using_default_llm_instance", model_name=model_name)
         return model_entry["llm"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,9 @@ services:
     environment:
       - APP_ENV=${APP_ENV:-development}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY must be set to a strong random value}
+      # The .env files say localhost, which is correct for `make dev` but unreachable
+      # from inside the container. Point at the compose service instead.
+      - POSTGRES_HOST=db
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Six independent bugs found while verifying the open PR/issue backlog. Each commit is standalone and separately verified against a real Docker stack.

Closes #97. Closes #92.

## 1. `make docker-up` was broken out of the box (two causes)

**`redis` missing → hard crash at import.** `redis` lives in the optional `cache` extra, which neither the Dockerfile (`uv sync --frozen`) nor `make install` (`uv sync`) installs. With `VALKEY_HOST` set — as `.env.development` ships — `limits` raised `ConfigurationError` while importing `app.core.limiter` and the container never started:

```
limits.errors.ConfigurationError: 'redis' prerequisite not available.
```

`cache.py` already degrades gracefully via `REDIS_AVAILABLE`; the limiter now reuses that flag and falls back to in-memory storage with a warning.

**`POSTGRES_HOST=localhost` inside the container.** The `.env` files are correct for `make dev` but unreachable from the container, so the app came up unable to reach its own database. Overridden in the compose `environment:` block, which takes precedence over `env_file`.

After both: `make docker-up` → `/health` 200, register/login/chat all 200.

## 2. Production served requests with no checkpointer (#97)

Confirmed reachable exactly as @M1ndSmith described. With a pool that fails to construct, on master in production:

```
warning  continuing_without_connection_pool  environment=production
info     graph_created  has_checkpointer=False  environment=production
  create_graph -> graph, checkpointer=None
```

The `AsyncPostgresSaver` is the only store for conversation history and HITL resume state, so the process kept answering while silently dropping both — and `/health` still reported `healthy`.

On this branch the same input raises and the service refuses to serve. Return types are tightened to non-`Optional` so the `None` path can't come back.

Worth noting a second, subtler variant found while testing: if the pool *constructs* but the database is unreachable, `open()` doesn't block, and the failure surfaces later at `checkpointer.setup()`. On master that hit the outer handler, logged `continuing_without_graph`, returned `None`, and every request then failed with a bare `RuntimeError` while `/health` stayed green. Same fix covers it.

## 3. Two `DatabaseService` instances (#92)

`DatabaseService.__init__` builds its own engine, so `db_service = DatabaseService()` in `auth.py` created a second connection pool alongside the module singleton — double the configured `POSTGRES_POOL_SIZE`. Verified: `auth.db_service is database_service` → `True`, same engine object.

## 4. `make migration` always produced a syntactically invalid file

`alembic/script.py.mako` line 1 was `"""${message | trim}."""` — the docstring closed on line 1, leaving `Revision ID:` / `Create Date:` as bare code:

```
old template: SyntaxError - unterminated triple-quoted string literal
new template: compiles
```

Generated a migration end-to-end to confirm; the existing files in `alembic/versions/` had evidently been hand-fixed.

## 5. `LLMRegistry.get()` sent the wrong model id on the override path

The kwargs branch built `ChatOpenAI(model=model_name)` — the *registry name*, not the model the entry was configured with — and also dropped `max_completion_tokens`. `service.py:258` takes this path during fallback, so whenever a name and its model diverged the override silently hit a different model than the default path did.

At the time this was written the `gpt-5.4` entry was configured `model="gpt-5"`, so the two paths disagreed. Section 6 fixes the underlying entry; this commit makes `get()` take the id from the entry either way, so the two paths can never diverge again.

## Verification

- full Docker stack: `/health` 200, register 200, login 200, chat 200, and `/chatbot/messages` reads the turn back out of the checkpointer
- before/after harness for #97 in both failure modes
- `ruff check`, `ruff format --check`, `pyright` clean; all six commits passed pre-commit

## Not included

`.env.production` is untracked, so two problems there are local-only and need fixing by hand: `DEFAULT_LLM_MODEL=gpt-4o-mini` isn't in `LLMRegistry.LLMS` (raises `ValueError` on first request), and its `JWT_SECRET_KEY` is 19 characters, which the guard merged in #95 now rejects.

---

## 6. Model registry moved to `gpt-5.6-luna` (added after review started)

Probed the live API rather than trusting the config. Findings:

- **`gpt-5.6` has no plain form** — it ships as `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra`. Using **luna**.
- **The `gpt-5` entry 400'd on every call.** It passed `top_p` / `presence_penalty` / `frequency_penalty`, which the API rejects once `reasoning` is set. It sat at the end of the circular fallback chain, so the chain died on its last hop. Every model here is a reasoning model, so the sampling knobs are removed and `reasoning.effort` is the only dial.
- **The `gpt-5.4` entry was configured `model="gpt-5"`** — a silent downgrade, since `gpt-5.4` is a real model. Pointed at the right one. (This also corrects the "alias" wording in the earlier registry commit: it was a bug, not an alias.)
- `max_completion_tokens` moved out of `model_kwargs`, silencing the `UserWarning` langchain printed on every startup.

Registry after the change, all verified live:

| name | model | effort | result |
|---|---|---|---|
| `gpt-5.6-luna` | `gpt-5.6-luna` | medium | OK |
| `gpt-5.4` | `gpt-5.4` | medium | OK |
| `gpt-5.4-mini` | `gpt-5.4-mini` | low | OK |
| `gpt-5.4-nano` | `gpt-5.4-nano` | low | OK |

End-to-end through the running stack: `default_model=gpt-5.6-luna model_index=0`, chat 200, `llm_response_generated model=gpt-5.6-luna`.

`DEFAULT_LLM_MODEL` updated in `.env.example` and the `config.py` fallback. Your untracked `.env.development` still pins `gpt-5.4-nano` — change it if you want luna locally.

## 7. Atlas Cloud model catalog refreshed (docs)

Fetched `https://api.atlascloud.ai/v1/models` (public, no key needed) and diffed it against the README table:

- **19 of the 62 listed models no longer exist** on Atlas Cloud (`deepseek-ai/DeepSeek-V3-0324`, `moonshotai/Kimi-K2-Instruct`, `MiniMaxAI/MiniMax-M2`, most of the `Qwen3-*` rows, …)
- ~93 live models were missing, including the entire `gpt-5.4`/`5.5`/`5.6` line, `claude-opus-5`, `glm-5.2`, `grok-4.6`, `kimi-k3`

Replaced with a curated 35-row selection, **every id asserted present in the live catalog**, led by `openai/gpt-5.6-luna` to match the new registry default. Relabelled "Full model catalog (59 LLMs)" → "Model catalog — a current selection (136 available in total)" so the live-list link stays the source of truth instead of a hand-copied table that rots.

Also confirmed while checking: the README's `OPENAI_BASE_URL` instruction genuinely works. Langchain's own `openai_api_base` field reads `None`, but the underlying SDK client resolves the env var — `client base_url = https://api.atlascloud.ai/v1/`. And Atlas Cloud carries `openai/gpt-5.6-luna`, so the new default is reachable through them too (with the `openai/` prefix).
