### PR TITLE
fix: URL-encode Postgres credentials in sync database URL builder

### DIFF
--- a/app/services/database.py
+++ b/app/services/database.py
@@ -4,6 +4,7 @@ from typing import (
     List,
     Optional,
 )
+from urllib.parse import quote_plus
 
 from fastapi import HTTPException
 from sqlalchemy.exc import SQLAlchemyError
@@ -40,7 +41,8 @@ class DatabaseService:
 
             # Create engine with appropriate pool configuration
             connection_url = (
-                f"postgresql://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}"
+                "postgresql://"
+                f"{quote_plus(settings.POSTGRES_USER)}:{quote_plus(settings.POSTGRES_PASSWORD)}"
                 f"@{settings.POSTGRES_HOST}:{settings.POSTGRES_PORT}/{settings.POSTGRES_DB}"
             )
 


### PR DESCRIPTION
The sync engine (DatabaseService) built its Postgres connection URL by interpolating POSTGRES_USER/POSTGRES_PASSWORD directly, while the async LangGraph checkpoint pool (app/core/langgraph/graph.py) already encodes them with quote_plus. Any credential containing a character like @, :, or # broke sync auth while async auth kept working.

This aligns the sync builder with the existing async pattern.

Fixes #99