### PR TITLE
fix: normalise email case at login so registered accounts can log in

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -219,7 +219,7 @@ async def login(
     """
     try:
         # Sanitize inputs
-        email = sanitize_string(email)
+        email = sanitize_string(email).lower()
         grant_type = sanitize_string(grant_type)
 
         # Verify grant type


### PR DESCRIPTION

## Summary
Registration stores the email lowercased and login looks it up as typed, so an account
registered with any capital letter in the address cannot be logged into.

## Impact
`sanitize_email()` ends `return email.lower()`, and registration passes the address through it
(`app/api/v1/auth.py:172`). Login does not — it calls `sanitize_string()`
(`app/api/v1/auth.py:222`), which does not change case. `DatabaseService.get_user_by_email` is an
exact match, `select(User).where(User.email == email)`, and Postgres compares `varchar`
case-sensitively.

Register `Zorion@Example.com` and the row is written `zorion@example.com`. Log in with the same
`Zorion@Example.com` and the lookup misses, so `/api/v1/auth/login` answers
`401 Incorrect email or password` for an account that exists.

There is no way out of it from the client side. Logging in as typed gives
`401 Incorrect email or password`; registering the same address again gives
`400 Email already registered`, because that check runs on the lowercased form
(`auth.py:179`); and there is no password-reset or account-recovery route in the app to fall back
on. Both messages read to the user as their own mistake, and only retyping the address in all
lowercase works.

This is the same register/login asymmetry as #96, on the neighbouring field.

## Changes
- `app/api/v1/auth.py` — lowercase the submitted email in `login()`, matching what
  `sanitize_email()` already does at registration. One line, no other behaviour touched.

## Validation
Exercised with the real `User` model, the real `sanitize_email` / `sanitize_string` from
`app/utils/sanitization.py`, and the `select(User).where(User.email == email)` statement from
`get_user_by_email`. Both normalisation statements are lifted out of `auth.py` by `ast`, so the
check is bound to the file rather than to a re-typed copy of it. `login()` itself is not invoked.

    patch applied    stored 'zorion@example.com' / queried 'zorion@example.com'  -> logs in
    patch reverted   stored 'zorion@example.com' / queried 'Zorion@Example.com'  -> no row, 401

Run against SQLite rather than Postgres; both compare TEXT case-sensitively by default, which is
the property under test. Not claimed: behaviour under `citext` or a case-insensitive collation —
the initial migration declares the column `AutoString` with no collation, so neither is in play
here.

Nothing to migrate: `sanitize_email()` has ended in `.lower()` since the initial commit
`2467e09`, and `create_user()` has exactly one caller, so no code path in this repo has ever
written a capitalised address.
